### PR TITLE
Add npm-run-all, chokidar-cli and watch scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,22 @@
         "copy": "cp -r src/copy/. dist",
         "copywin": "cmd /c xcopy src\\copy\\. dist /s /e /y",
         "build": "npm run clean && npm run js && npm run css && npm run svg && npm run img && npm run copy",
-        "buildwin": "cmd /c npm run cleanwin && npm run js && npm run css && npm run svg && npm run img && npm run copywin"
+        "buildwin": "cmd /c npm run cleanwin && npm run js && npm run css && npm run svg && npm run img && npm run copywin",
+        "watch-css": "chokidar \"./src/**/*.scss\" -c \"npm run css\"",
+        "watch-js": "chokidar \"./src/**/*.js\" -c \"npm run js\"",
+        "watch-svg": "chokidar \"./src/**/*.svg\" -c \"npm run build\"",
+        "watch-img": "chokidar \"./src/img/**/*.*\" -c \"npm run build\"",
+        "watch-copy": "chokidar \"./src/copy/**/*.*\" -c \"npm run build\"",
+        "watch": "npm-run-all --parallel watch-css watch-js watch-svg watch-img watch-copy"
     },
     "devDependencies": {
+        "chokidar-cli": "^2.1.0",
         "imagemin-cli": "^6.0.0",
         "imagemin-mozjpeg": "^8.0.0",
         "imagemin-pngcrush": "^6.0.0",
         "imagemin-pngquant": "^8.0.0",
         "imagemin-zopfli": "^6.0.0",
+        "npm-run-all": "^4.1.5",
         "rollup": "^2.6.1",
         "rollup-plugin-terser": "^7.0.2",
         "sass": "^1.26.5",


### PR DESCRIPTION
Added watch scripts, with dependencies on npm-run-all and chokidar-cli to make them work.