### PR TITLE
Optimize *.svg files in folders recursively with `-r`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "clean": "recursive-delete 'dist'",
         "js": "rollup --config",
         "css": "node sass.js",
-        "svg": "svgo -f src/svg dist/svg --disable=removeViewBox,removeTitle",
+        "svg": "svgo -f src/svg dist/svg -r --disable=removeViewBox,removeTitle",
         "img": "imagemin src/img/* --out-dir=dist/img --plugin=pngquant --plugin=mozjpeg --plugin=pngcrush --plugin=zopfli",
         "copy": "recursive-copy 'src/copy' 'dist'",
         "build-dirty": "npm-run-all -p js css svg img copy",


### PR DESCRIPTION
Kind of a buried feature of `svgo`, but optimizing SVGs in nested directories is likely expected behavior for a project like this. This way if you have an icon lib, you can plunk it in the SVG folder and it will be minified, batteries included.

`./node_modules/svgo/bin/svgo --help`