### PR TITLE
replace deprecated rollup plugin terser with new one on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The boilerplate uses [rollup.js](https://rollupjs.org) with the [terser](https:/
 {
     "devDependencies": {
         "rollup": "^2.6.1",
-        "rollup-plugin-terser": "^7.0.2"
+        "@rollup/plugin-terser": "^0.2.0"
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "build-tools-boilerplate",
+    "name": "build-tool-boilerplate",
     "version": "2.0.0",
     "description": "Simple recipes for building and compiling with the CLI.",
     "author": {
@@ -9,7 +9,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "http://github.com/cferdinandi/build-tools-boilerplate"
+        "url": "http://github.com/cferdinandi/build-tool-boilerplate"
     },
     "scripts": {
         "clean": "recursive-delete 'dist'",
@@ -33,7 +33,7 @@
         "npm-run-all": "^4.1.5",
         "recursive-fs": "^2.1.0",
         "rollup": "^2.6.1",
-        "rollup-plugin-terser": "^7.0.2",
+        "@rollup/plugin-terser": "^0.2.0",
         "sass": "^1.26.5",
         "svgo": "^1.3.2",
         "imagemin-cli": "^6.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 // Plugins
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import pkg from './package.json';
 
 


### PR DESCRIPTION
Installing from `package.json` - `npm install` gives a deprecated warning for the rollup plugin terser, this PR should fix this, and is working AFAIK. Love this build tool boilerplate BTW 😉 